### PR TITLE
[JESS-994] Fix rendering on iOS (and first refresh of skinny browser windows)

### DIFF
--- a/static/coolascii.js
+++ b/static/coolascii.js
@@ -18,7 +18,7 @@ function calculate_padding(width_of_content, padding_char="~") {
 
 function print_to_page(block_of_text) {
     var header = "";  // The final text to be put on the page
-    var padding = " ".repeat( calculate_padding(block_of_text.content_width) );
+    var padding = " ".repeat(Math.min(0, calculate_padding(block_of_text.content_width)));
     var lines = block_of_text.plain_content.split("\n");
     for (var i=0; i<lines.length; i++){
         header += padding+lines[i]+padding+"<br/>"


### PR DESCRIPTION
The page will appear to not display text when, in `calculate_padding()`, the calculated `screenwidth_in_chars` is smaller than the calculated `width_of_content`.

Where this is the case, the `" ".repeat(calculate_padding(...))` on line 21 will attempt to repeat `" "` a negative amount of times, eg. a screen-width of 47 and a content-width of 52 results in `" ".repeat(-5)`.

This means the first render on iOS breaks, and the page will show up as blank.

(You can test this on desktop by making the page really skinny, then refreshing; it'll be broken until you resize.)